### PR TITLE
docs: fix simple typo, inefficent -> inefficient

### DIFF
--- a/lexer.h
+++ b/lexer.h
@@ -67,7 +67,7 @@ DEFINES:
 
     LEXER_MEMSET
         You can define this to 'memset' or your own memset replacement.
-        If not lexer uses a naive (maybe inefficent) implementation.
+        If not lexer uses a naive (maybe inefficient) implementation.
 
 
 LIMITATIONS:

--- a/sched.h
+++ b/sched.h
@@ -36,7 +36,7 @@ DEFINE:
 
     SCHED_MEMSET
         You can define this to 'memset' or your own memset replacement.
-        If not, sched.h uses a naive (maybe inefficent) implementation.
+        If not, sched.h uses a naive (maybe inefficient) implementation.
 
     SCHED_INT32
     SCHED_UINT32

--- a/vec.h
+++ b/vec.h
@@ -42,11 +42,11 @@ DEFINES:
 
     MMX_MEMSET
         You can define this to 'memset' or your own memset replacement.
-        If not, mm_vec.h uses a naive (maybe inefficent) implementation.
+        If not, mm_vec.h uses a naive (maybe inefficient) implementation.
 
     MMX_MEMCPY
         You can define this to 'memcpy' or your own memcpy replacement.
-        If not, mm_vec.h uses a naive (maybe inefficent) implementation.
+        If not, mm_vec.h uses a naive (maybe inefficient) implementation.
 
     MMX_USE_DEGREES
         If this is set all angles inside the library, input as well as output,


### PR DESCRIPTION
There is a small typo in lexer.h, sched.h, vec.h.

Should read `inefficient` rather than `inefficent`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md