### PR TITLE
sdefl: Use byte stores in sdefl_put16

### DIFF
--- a/sdefl.h
+++ b/sdefl.h
@@ -506,9 +506,10 @@ sdefl_blk_type(const struct sdefl *s, int blk_len, int pre_item_len,
 }
 static void
 sdefl_put16(unsigned char **dst, unsigned short x) {
-  unsigned short *val = (unsigned short*)(void*)(*dst);
-  *val = (unsigned short)x;
-  *dst += 2;
+  unsigned char *val = *dst;
+  val[0] = (unsigned char)(x & 0xff);
+  val[1] = (unsigned char)(x >> 8);
+  *dst = val + 2;
 }
 static void
 sdefl_match(unsigned char **dst, struct sdefl *s, int dist, int len) {


### PR DESCRIPTION
deflate specification requires little endian storage of 16-bit fields like stored block lengths. The existing code would create malformed outputs on big-endian architectures, and also triggers sanitizer errors due to unsigned short store being unaligned, as well as having a potential to crash on unaligned writes on some architectures.

The two-byte store is optimized by gcc/clang when targeting x64/arm64 so this should be as efficient but safer.

MSVC doesn't recognize the idiom unfortunately, but these are used very rarely and maybe MSVC optimizer will improve
in the future...