### PR TITLE
Fix warning from clang compiler

### DIFF
--- a/sinfl.h
+++ b/sinfl.h
@@ -169,7 +169,7 @@ extern int zsinflate(void *out, int cap, const void *in, int size);
 #endif
 
 static int
-sinfl_bsr(unsigned n) {
+sinfl_bsr(unsigned long n) {
 #ifdef _MSC_VER
   _BitScanReverse(&n, n);
   return n;


### PR DESCRIPTION
- The following warning was fixed:
>  warning: incompatible pointer types passing 'unsigned int *' to parameter of type 'unsigned long *' [-Wincompatible-pointer-types]