### PR TITLE
deflate allows non-compressed blocks with LEN=0

### DIFF
--- a/sinfl.h
+++ b/sinfl.h
@@ -410,7 +410,7 @@ sinfl_decompress(unsigned char *out, int cap, const unsigned char *in, int size)
 
       if ((unsigned short)len != (unsigned short)~nlen)
         return (int)(out-o);
-      if (len > (e - s.bitptr) || !len)
+      if (len > (e - s.bitptr))
         return (int)(out-o);
 
       memcpy(out, s.bitptr, (size_t)len);


### PR DESCRIPTION
RFC 1951 does not forbid LEN=0 for non-compressed blocks.

See also this comment in puff source: https://github.com/madler/zlib/blob/5a82f71ed1dfc0bec044d9702463dbdf84ea3b71/contrib/puff/puff.c#L161-L162